### PR TITLE
Pipeline refactor

### DIFF
--- a/app/controllers/api/v1/authenticated_controller.rb
+++ b/app/controllers/api/v1/authenticated_controller.rb
@@ -11,7 +11,7 @@ module Api
         return if @current_user = find_user
 
         error_message = 'Get a token by posting email to /api/v1/users/create'
-        json_response({ message: error_message },:unauthorized)
+        json_response({ message: error_message }, :unauthorized)
       end
 
       def find_user

--- a/app/controllers/api/v1/quotes_controller.rb
+++ b/app/controllers/api/v1/quotes_controller.rb
@@ -5,7 +5,7 @@ module Api
     class QuotesController < AuthenticatedController
       def index
         quotes = Quote.includes(:season, :character, :episode)
-        json_response({quotes: quotes})
+        json_response({ quotes: quotes })
       end
 
       def show

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -5,10 +5,10 @@ module Api
     class SearchesController < AuthenticatedController
       def create
         searcher = create_searcher
-        searcher.search
+        results = searcher.search
 
-        if searcher.errors.blank?
-          json_response({ quotes: searcher.quotes })
+        if results
+          json_response({ quotes: results })
         else
           json_response({ message: searcher.errors }, :bad_request)
         end

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -8,9 +8,9 @@ module Api
         searcher.search
 
         if searcher.errors.blank?
-          json_response({quotes: searcher.quotes})
+          json_response({ quotes: searcher.quotes })
         else
-          json_response({message: searcher.errors}, :bad_request)
+          json_response({ message: searcher.errors }, :bad_request)
         end
       end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,6 @@
 module Api
   module V1
     class UsersController < ApplicationController
-
       # POST /api/v1/users
       def create
         user = User.new(user_params)
@@ -12,7 +11,7 @@ module Api
           user = ::UserSupport::CreateJson.new(user)
           render json: user, status: :created
         else
-          render json: user.errors, status: :unprocessable_entity
+          json_response({ message: user.errors.full_messages }, :unprocessable_entity)
         end
       end
 

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ExceptionHandler
   extend ActiveSupport::Concern
 

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Response
   def json_response(object, status = :ok)
     render json: object, status: status

--- a/app/lib/search_support/cache_reader.rb
+++ b/app/lib/search_support/cache_reader.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SearchSupport
+  class CacheReader
+    include SearchSupport::ExceptionHandler
+
+    class << self
+      def execute(results_builder)
+        results = read_cache(results_builder)
+        if results.present?
+          results_builder.results = results
+          results_builder.complete!
+        end
+      rescue StandardError => e
+        record_errors_and_terminate(e, results_builder)
+      end
+
+      private
+
+      def read_cache(results_builder)
+        Rails.cache.read(results_builder)
+      end
+    end
+  end
+end

--- a/app/lib/search_support/cache_writer.rb
+++ b/app/lib/search_support/cache_writer.rb
@@ -2,16 +2,14 @@
 
 module SearchSupport
   class CacheWriter
-    def initialize(results)
-      @results = results
+    include SearchSupport::ExceptionHandler
+
+    class << self
+      def execute(results_builder)
+        Rails.cache.write(results_builder, results_builder.results)
+      rescue StandardError => e
+        record_errors_and_terminate(e, results_builder)
+      end
     end
-
-    def execute
-      Rails.cache.write(results, results.scope)
-    end
-
-    private
-
-    attr_reader :results
   end
 end

--- a/app/lib/search_support/cache_writer.rb
+++ b/app/lib/search_support/cache_writer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SearchSupport
+  class CacheWriter
+    def initialize(results)
+      @results = results
+    end
+
+    def execute
+      Rails.cache.write(results, results.scope)
+    end
+
+    private
+
+    attr_reader :results
+  end
+end

--- a/app/lib/search_support/exception_handler.rb
+++ b/app/lib/search_support/exception_handler.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module SearchSupport
+  module ExceptionHandler
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def record_errors_and_terminate(e, results_builder)
+        results_builder.complete!
+        results_builder.errors = e.message
+      end
+    end
+  end
+end

--- a/app/lib/search_support/filterer.rb
+++ b/app/lib/search_support/filterer.rb
@@ -18,6 +18,8 @@ module SearchSupport
       Rails.logger.error { full_message }
     end
 
+    private
+
     def filters
       @filters ||= @results.search_params['filters']
     end

--- a/app/lib/search_support/orchestrator.rb
+++ b/app/lib/search_support/orchestrator.rb
@@ -2,52 +2,51 @@
 
 module SearchSupport
   class Orchestrator
-    attr_reader :results
-
-    def initialize(search_params:, user:)
-      @results = SearchSupport::Results.new(
-        user: user,
-        scope: initial_scope,
-        search_params: search_params.freeze
-      )
-    end
+    attr_reader :errors
 
     STEPS = [
-      SearchSupport::Searcher,
-      SearchSupport::Filterer,
-      SearchSupport::Sorter,
-      SearchSupport::Recorder,
-      SearchSupport::CacheWriter
+        SearchSupport::CacheReader,
+        SearchSupport::Searcher,
+        SearchSupport::Filterer,
+        SearchSupport::Sorter,
+        SearchSupport::CacheWriter
     ].freeze
 
-    def errors
-      results.errors
-    end
-
-    def quotes
-      results.scope
-    end
-
-    def search
-      return if set_from_cache
-
-      STEPS.each do |step_klass|
-        return if errors.present?
-
-        step_klass.new(results).execute
-      end
-    end
-
-    private
-
-    def set_from_cache
-      if (quotes = Rails.cache.read(results))
-        results.scope = quotes
-      end
+    def initialize(search_params:, user:)
+      @results_builder = SearchSupport::ResultsBuilder.new(
+        scope: initial_scope,
+        user: user,
+        search_params: search_params.freeze
+      )
     end
 
     def initial_scope
       Quote.includes(:character, :episode, :season)
     end
+
+    # The results_builder holds a results which is a scope that continues to be whittled
+    # down as the pipeline moves. If the completed flag is set, the loop stops. If errors
+    # are present, errors are set on this the Orchestrator object. Otherwise, the whittled
+    # down scope is returns.
+    def search
+      STEPS.each do |step_klass|
+        step_klass.execute(results_builder)
+        break if results_builder.complete?
+      end
+
+      record_search
+      if results_builder.errors.blank?
+        results_builder.results
+      else
+        @errors = results_builder.errors
+        false
+      end
+    end
+
+    def record_search
+      SearchSupport::Recorder.execute(results_builder)
+    end
+
+    attr_reader :results_builder
   end
 end

--- a/app/lib/search_support/orchestrator.rb
+++ b/app/lib/search_support/orchestrator.rb
@@ -39,6 +39,8 @@ module SearchSupport
       Rails.cache.write(results, results.scope) if errors.blank?
     end
 
+    private
+
     def set_from_cache
       if quotes = Rails.cache.read(results)
         results.scope = quotes

--- a/app/lib/search_support/orchestrator.rb
+++ b/app/lib/search_support/orchestrator.rb
@@ -16,7 +16,8 @@ module SearchSupport
       SearchSupport::Searcher,
       SearchSupport::Filterer,
       SearchSupport::Sorter,
-      SearchSupport::Recorder
+      SearchSupport::Recorder,
+      SearchSupport::CacheWriter
     ].freeze
 
     def errors
@@ -35,14 +36,12 @@ module SearchSupport
 
         step_klass.new(results).execute
       end
-
-      Rails.cache.write(results, results.scope) if errors.blank?
     end
 
     private
 
     def set_from_cache
-      if quotes = Rails.cache.read(results)
+      if (quotes = Rails.cache.read(results))
         results.scope = quotes
       end
     end

--- a/app/lib/search_support/orchestrator.rb
+++ b/app/lib/search_support/orchestrator.rb
@@ -5,11 +5,11 @@ module SearchSupport
     attr_reader :errors
 
     STEPS = [
-        SearchSupport::CacheReader,
-        SearchSupport::Searcher,
-        SearchSupport::Filterer,
-        SearchSupport::Sorter,
-        SearchSupport::CacheWriter
+      SearchSupport::CacheReader,
+      SearchSupport::Searcher,
+      SearchSupport::Filterer,
+      SearchSupport::Sorter,
+      SearchSupport::CacheWriter
     ].freeze
 
     def initialize(search_params:, user:)
@@ -20,14 +20,10 @@ module SearchSupport
       )
     end
 
-    def initial_scope
-      Quote.includes(:character, :episode, :season)
-    end
-
-    # The results_builder holds a results which is a scope that continues to be whittled
-    # down as the pipeline moves. If the completed flag is set, the loop stops. If errors
-    # are present, errors are set on this the Orchestrator object. Otherwise, the whittled
-    # down scope is returns.
+    # The results_builder holds a results which is a scope that continues to be narrowed
+    # and transformed as the pipeline moves. If the completed flag is set, the loop stops.
+    # If no errors are present, the narrowed scope is returned. Otherwise, false is returned
+    # and errors are set to be read from this object.
     def search
       STEPS.each do |step_klass|
         step_klass.execute(results_builder)
@@ -43,10 +39,16 @@ module SearchSupport
       end
     end
 
+    private
+
+    attr_reader :results_builder
+
     def record_search
       SearchSupport::Recorder.execute(results_builder)
     end
 
-    attr_reader :results_builder
+    def initial_scope
+      Quote.includes(:character, :episode, :season)
+    end
   end
 end

--- a/app/lib/search_support/recorder.rb
+++ b/app/lib/search_support/recorder.rb
@@ -2,20 +2,18 @@
 
 module SearchSupport
   class Recorder
-    def initialize(results)
-      @results = results
-    end
+    class << self
+      def execute(results_builder)
+        search = Search.where(criteria: search_criteria(results_builder).downcase)
+                       .first_or_create
+        results_builder.user.searches << search
+      end
 
-    def execute
-      search = Search.where(criteria: search_criteria.downcase)
-                     .first_or_create
-      @results.user.searches << search
-    end
+      private
 
-    private
-
-    def search_criteria
-      @results.search_params['match_text'] || ''
+      def search_criteria(results_builder)
+        results_builder.search_params['match_text'] || ''
+      end
     end
   end
 end

--- a/app/lib/search_support/recorder.rb
+++ b/app/lib/search_support/recorder.rb
@@ -8,7 +8,7 @@ module SearchSupport
 
     def execute
       search = Search.where(criteria: search_criteria.downcase)
-          .first_or_create
+                     .first_or_create
       @results.user.searches << search
     end
 

--- a/app/lib/search_support/recorder.rb
+++ b/app/lib/search_support/recorder.rb
@@ -6,14 +6,16 @@ module SearchSupport
       @results = results
     end
 
-    def search_criteria
-      @results.search_params['match_text'] || ''
-    end
-
     def execute
       search = Search.where(criteria: search_criteria.downcase)
-                     .first_or_create
+          .first_or_create
       @results.user.searches << search
+    end
+
+    private
+
+    def search_criteria
+      @results.search_params['match_text'] || ''
     end
   end
 end

--- a/app/lib/search_support/results_builder.rb
+++ b/app/lib/search_support/results_builder.rb
@@ -1,19 +1,14 @@
 # frozen_string_literal: true
 
 module SearchSupport
-  class Results
-    attr_accessor :scope
-    attr_reader :user, :search_params, :errors
+  class ResultsBuilder
+    attr_accessor :results, :errors
+    attr_reader :user, :search_params
 
     def initialize(user:, search_params:, scope:)
       @user = user
       @search_params = search_params
-      @scope = scope
-      @errors = []
-    end
-
-    def add_error(error)
-      @errors << error
+      @results = scope
     end
 
     def cache_key
@@ -21,6 +16,14 @@ module SearchSupport
         search_params: search_params.to_h,
         quotes_updated: Quote.maximum(:updated_at)
       }
+    end
+
+    def complete!
+      @completed = true
+    end
+
+    def complete?
+      !!@completed
     end
   end
 end

--- a/app/lib/search_support/searcher.rb
+++ b/app/lib/search_support/searcher.rb
@@ -2,26 +2,22 @@
 
 module SearchSupport
   class Searcher
-    def initialize(results)
-      @results = results
-    end
+    include SearchSupport::ExceptionHandler
 
-    def execute
-      @results.scope = @results.scope
-                               .where('body ILIKE ?', "%#{match_text}%")
-    rescue StandardError => e
-      message = 'Bad search attempted'
-      backtrace = e.backtrace.join("\n")
-      full_message = "#{message}\n#{e.message}\n#{backtrace}"
+    class << self
+      def execute(results_builder)
+        results = results_builder.results
+                                 .where('body ILIKE ?', "%#{match_text(results_builder)}%")
+        results_builder.results = results
+      rescue StandardError => e
+        record_errors_and_terminate(e, results_builder)
+      end
 
-      @results.errors << message
-      Rails.logger.error { full_message }
-    end
+      private
 
-    private
-
-    def match_text
-      @results.search_params['match_text'] || ''
+      def match_text(results_builder)
+        results_builder.search_params['match_text'] || ''
+      end
     end
   end
 end

--- a/app/lib/search_support/searcher.rb
+++ b/app/lib/search_support/searcher.rb
@@ -8,7 +8,7 @@ module SearchSupport
 
     def execute
       @results.scope = @results.scope
-          .where('body ILIKE ?', "%#{match_text}%")
+                               .where('body ILIKE ?', "%#{match_text}%")
     rescue StandardError => e
       message = 'Bad search attempted'
       backtrace = e.backtrace.join("\n")

--- a/app/lib/search_support/searcher.rb
+++ b/app/lib/search_support/searcher.rb
@@ -6,13 +6,9 @@ module SearchSupport
       @results = results
     end
 
-    def match_text
-      @results.search_params['match_text'] || ''
-    end
-
     def execute
       @results.scope = @results.scope
-                               .where('body ILIKE ?', "%#{match_text}%")
+          .where('body ILIKE ?', "%#{match_text}%")
     rescue StandardError => e
       message = 'Bad search attempted'
       backtrace = e.backtrace.join("\n")
@@ -20,6 +16,12 @@ module SearchSupport
 
       @results.errors << message
       Rails.logger.error { full_message }
+    end
+
+    private
+
+    def match_text
+      @results.search_params['match_text'] || ''
     end
   end
 end

--- a/app/lib/search_support/sorter.rb
+++ b/app/lib/search_support/sorter.rb
@@ -2,30 +2,19 @@
 
 module SearchSupport
   class Sorter
-    def initialize(results)
-      @results = results
-    end
+    include SearchSupport::ExceptionHandler
 
-    def execute
-      return unless sort_params.present?
+    class << self
+      def execute(results_builder)
+        sort_params = results_builder.search_params['sort']
+        return unless sort_params.present?
 
-      @results.scope = @results.scope
-                               .order(
-                                 body: sort_params['body'].to_sym
-                               )
-    rescue StandardError => e
-      message = 'Bad sort attempted'
-      backtrace = e.backtrace.join("\n")
-      full_message = "#{message}\n#{e.message}\n#{backtrace}"
-
-      @results.errors << message
-      Rails.logger.error { full_message }
-    end
-
-    private
-
-    def sort_params
-      @results.search_params['sort']
+        results = results_builder.results
+                                 .order(body: sort_params['body'].to_sym)
+        results_builder.results = results
+      rescue StandardError => e
+        record_errors_and_terminate(e, results_builder)
+      end
     end
   end
 end

--- a/app/lib/search_support/sorter.rb
+++ b/app/lib/search_support/sorter.rb
@@ -10,9 +10,9 @@ module SearchSupport
       return unless sort_params.present?
 
       @results.scope = @results.scope
-          .order(
-      body: sort_params['body'].to_sym
-      )
+                               .order(
+                                 body: sort_params['body'].to_sym
+                               )
     rescue StandardError => e
       message = 'Bad sort attempted'
       backtrace = e.backtrace.join("\n")

--- a/app/lib/search_support/sorter.rb
+++ b/app/lib/search_support/sorter.rb
@@ -6,17 +6,13 @@ module SearchSupport
       @results = results
     end
 
-    def sort_params
-      @results.search_params['sort']
-    end
-
     def execute
       return unless sort_params.present?
 
       @results.scope = @results.scope
-                               .order(
-                                 body: sort_params['body'].to_sym
-                               )
+          .order(
+      body: sort_params['body'].to_sym
+      )
     rescue StandardError => e
       message = 'Bad sort attempted'
       backtrace = e.backtrace.join("\n")
@@ -24,6 +20,12 @@ module SearchSupport
 
       @results.errors << message
       Rails.logger.error { full_message }
+    end
+
+    private
+
+    def sort_params
+      @results.search_params['sort']
     end
   end
 end

--- a/app/lib/seinfeld_etl/transformer.rb
+++ b/app/lib/seinfeld_etl/transformer.rb
@@ -4,7 +4,7 @@ module SeinfeldEtl
   class Transformer
     def transform(row)
       raw_attributes.map do |raw_attribute_key|
-        self.send("map_#{raw_attribute_key}".to_sym, row[raw_attribute_key])
+        send("map_#{raw_attribute_key}".to_sym, row[raw_attribute_key])
       end.to_h
     end
 

--- a/app/lib/user_support/create_json.rb
+++ b/app/lib/user_support/create_json.rb
@@ -2,8 +2,6 @@
 
 module UserSupport
   class CreateJson
-    attr_reader :user
-
     def initialize(user)
       @user = user
     end
@@ -14,5 +12,9 @@ module UserSupport
         token: user.token
       }
     end
+
+    private
+
+    attr_reader :user
   end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -7,6 +7,8 @@ class Search < ApplicationRecord
   validates :criteria, uniqueness: true
   before_validation :downcase_criteria
 
+  private
+
   def downcase_criteria
     self.criteria ||= ''
     self.criteria = criteria.downcase

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
   validates :token, presence: true, uniqueness: true
   before_validation :set_token
 
+  private
+
   def downcase_email
     self.email ||= ''
     self.email = email.downcase

--- a/spec/controllers/api/v1/searches_controller_spec.rb
+++ b/spec/controllers/api/v1/searches_controller_spec.rb
@@ -17,9 +17,7 @@ describe Api::V1::SearchesController do
 
   it 'calls the searcher' do
     searcher = double(:searcher,
-                      search: nil,
-                      errors: [],
-                      quotes: Quote.none)
+                      search: true)
     allow(SearchSupport::Orchestrator).to receive(:new) { searcher }
 
     params = {

--- a/spec/lib/search_support/filterer_spec.rb
+++ b/spec/lib/search_support/filterer_spec.rb
@@ -22,15 +22,6 @@ describe SearchSupport::Filterer do
   end
   let(:scope) { Quote.includes(:character).where(id: quotes.map(&:id)) }
 
-  def build_results(user, scope, filter_params)
-    search_params = build_search_params(filter_params)
-    SearchSupport::Results.new(
-      user: user,
-      scope: scope,
-      search_params: search_params
-    )
-  end
-
   context 'character filtering -' do
     it 'filters for only' do
       filters = {
@@ -38,13 +29,12 @@ describe SearchSupport::Filterer do
           'characters' => ['George']
         }
       }
-      results = build_results(user, scope, filters: filters)
+      results_builder = build_results(user, scope, filters: filters)
 
-      filterer = described_class.new(results)
-      filterer.execute
+      results = described_class.execute(results_builder)
 
-      expect(results.errors).to be_empty
-      expect(results.scope.distinct.pluck(:name)).to eq(['George'])
+      expect(results_builder.errors).to be_blank
+      expect(results.distinct.pluck(:name)).to eq(['George'])
     end
 
     it 'filters for not' do
@@ -53,13 +43,12 @@ describe SearchSupport::Filterer do
           'characters' => ['George']
         }
       }
-      results = build_results(user, scope, filters: filters)
+      results_builder = build_results(user, scope, filters: filters)
 
-      filterer = described_class.new(results)
-      filterer.execute
+      results = described_class.execute(results_builder)
 
-      expect(results.errors).to be_empty
-      expect(results.scope.distinct.pluck(:name)).to match_array(['Paul'])
+      expect(results_builder.errors).to be_blank
+      expect(results.distinct.pluck(:name)).to match_array(['Paul'])
     end
   end
 end

--- a/spec/lib/search_support/recorder_spec.rb
+++ b/spec/lib/search_support/recorder_spec.rb
@@ -8,7 +8,7 @@ describe SearchSupport::Recorder do
 
   def build_results(user, scope, match_text_params)
     search_params = build_search_params(match_text_params)
-    SearchSupport::Results.new(
+    SearchSupport::ResultsBuilder.new(
       user: user,
       scope: scope,
       search_params: search_params
@@ -18,10 +18,9 @@ describe SearchSupport::Recorder do
   it 'records the search given criteria and a user' do
     Search.find_by(criteria: 'yada')&.destroy # just in case
 
-    results = build_results(user, scope, { match_text: 'yada' })
-    recorder = described_class.new(results)
+    results_builder = build_results(user, scope, { match_text: 'yada' })
 
-    recorder.execute
+    described_class.execute(results_builder)
 
     search = Search.find_by(criteria: 'yada')
     expect(search).to be_a(Search)
@@ -32,10 +31,9 @@ describe SearchSupport::Recorder do
     Search.where(criteria: 'shmoopy').first_or_create
     search = Search.find_by(criteria: 'shmoopy')
 
-    results = build_results(user, scope, { match_text: 'shmoopy' })
-    recorder = described_class.new(results)
+    results_builder = build_results(user, scope, { match_text: 'shmoopy' })
 
-    recorder.execute
+    described_class.execute(results_builder)
 
     expect(user.searches).to include(search)
   end
@@ -44,10 +42,9 @@ describe SearchSupport::Recorder do
     Search.where(criteria: 'shmoopy').first_or_create
     search = Search.find_by(criteria: 'shmoopy')
 
-    results = build_results(user, scope, { match_text: 'Shmoopy' })
-    recorder = described_class.new(results)
+    results_builder = build_results(user, scope, { match_text: 'Shmoopy' })
 
-    recorder.execute
+    described_class.execute(results_builder)
 
     expect(user.searches).to include(search)
   end
@@ -59,11 +56,10 @@ describe SearchSupport::Recorder do
     user = create(:user)
     user.searches << search
 
-    results = build_results(user, scope, { match_text: 'shmoopy' })
-    recorder = described_class.new(results)
+    results_builder = build_results(user, scope, { match_text: 'shmoopy' })
 
     expect do
-      recorder.execute
+      described_class.execute(results_builder)
     end.to change { UserSearch.where(user: user, search: search).count }.by(1)
   end
 end

--- a/spec/lib/search_support/results_builder_spec.rb
+++ b/spec/lib/search_support/results_builder_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe SearchSupport::Results do
+describe SearchSupport::ResultsBuilder do
   let(:user) { create :user }
   let(:scope) { Quote.all }
   let(:search_params) do
@@ -24,18 +24,18 @@ describe SearchSupport::Results do
     end.to raise_error NoMethodError
   end
 
-  it 'has a writeable search scope' do
+  it 'has a writeable search results' do
     quote = create(:quote, body: 'aaaaaaaa')
-    expect(results.scope).to eq(scope)
-    expect(results.scope).to include(quote)
+    expect(results.results).to eq(scope)
+    expect(results.results).to include(quote)
 
-    results.scope = results.scope.where(body: 'zzzzzz')
+    results.results = results.results.where(body: 'zzzzzz')
 
-    expect(results.scope).to_not include(quote)
+    expect(results.results).to_not include(quote)
   end
 
   it 'has error storage' do
-    results.add_error 'this did not go well'
+    results.errors = 'this did not go well'
     expect(results.errors).to include('this did not go well')
   end
 end

--- a/spec/lib/search_support/searcher_spec.rb
+++ b/spec/lib/search_support/searcher_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe SearchSupport::Searcher do
   let(:user) { double(:user) }
   let(:scope) { Quote.all }
-  let(:body) {'The quick brown fox jumped over the lazy dog.'}
+  let(:body) { 'The quick brown fox jumped over the lazy dog.' }
 
   it 'finds exactly' do
     quote = create(:quote, body: body)

--- a/spec/lib/search_support/searcher_spec.rb
+++ b/spec/lib/search_support/searcher_spec.rb
@@ -5,53 +5,44 @@ require 'rails_helper'
 describe SearchSupport::Searcher do
   let(:user) { double(:user) }
   let(:scope) { Quote.all }
-  let(:body) { 'The quick brown fox jumped over the lazy dog.' }
-
-  def build_results(user, scope, search_text)
-    search_params = build_search_params(match_text: search_text)
-    SearchSupport::Results.new(
-      user: user,
-      scope: scope,
-      search_params: search_params
-    )
-  end
+  let(:body) {'The quick brown fox jumped over the lazy dog.'}
 
   it 'finds exactly' do
     quote = create(:quote, body: body)
 
-    results = build_results(user, scope, body)
-    described_class.new(results).execute
+    results_builder = build_results(user, scope, match_text: body)
+    described_class.execute(results_builder)
 
-    expect(results.scope).to include(quote)
+    expect(results_builder.results).to include(quote)
   end
 
   it 'find partial' do
     quote = create(:quote, body: body)
 
-    results = build_results(user, scope, 'fox')
-    described_class.new(results).execute
+    results_builder = build_results(user, scope, match_text: 'fox')
+    described_class.execute(results_builder)
 
-    expect(results.scope).to include(quote)
+    expect(results_builder.results).to include(quote)
   end
 
   it 'find case insensitively' do
     quote = create(:quote, body: body)
 
-    results = build_results(user, scope, 'juMPed')
-    described_class.new(results).execute
+    results_builder = build_results(user, scope, match_text: 'juMPed')
+    described_class.execute(results_builder)
 
-    expect(results.scope).to include(quote)
+    expect(results_builder.results).to include(quote)
   end
 
   it 'errors will be recorded' do
-    bad_scope_results = SearchSupport::Results.new(
+    bad_scope_results = SearchSupport::ResultsBuilder.new(
       user: user,
       scope: 'Not an ActiveRecordScope',
       search_params: 'Not a hash'
     )
 
     expect do
-      described_class.new(bad_scope_results).execute
+      described_class.execute(bad_scope_results)
     end.to_not raise_error
 
     expect(bad_scope_results.errors).to be_present

--- a/spec/lib/search_support/sorter_spec.rb
+++ b/spec/lib/search_support/sorter_spec.rb
@@ -19,10 +19,10 @@ describe SearchSupport::Sorter do
     described_class.execute(results_builder)
 
     expect(results_builder.results.pluck(:body)).to eq([
-                                               'aaa auto',
-                                               'mmm middle of the road',
-                                               'zzz tax evasion'
-                                             ])
+                                                         'aaa auto',
+                                                         'mmm middle of the road',
+                                                         'zzz tax evasion'
+                                                       ])
   end
 
   it 'sorts by quote body - descending' do
@@ -31,10 +31,10 @@ describe SearchSupport::Sorter do
     described_class.execute(results_builder)
 
     expect(results_builder.results.pluck(:body)).to eq([
-                                               'zzz tax evasion',
-                                               'mmm middle of the road',
-                                               'aaa auto'
-                                             ])
+                                                         'zzz tax evasion',
+                                                         'mmm middle of the road',
+                                                         'aaa auto'
+                                                       ])
   end
 
   it 'errors for non-body sorts' do

--- a/spec/requests/quotes_spec.rb
+++ b/spec/requests/quotes_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'quotes', type: :request do
       response '200', 'quote retrieved' do
         let(:token) { @user.token }
         let(:id) { @demo_quotes.first.id }
-        run_test! do |response|
+        run_test! do |_response|
           received_quote = json_body['quote']
           remote_quote = Quote.find(@demo_quotes.first.id)
 

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'search', type: :request do
         let(:search) do
           { "search": {
             "match_text": 'hello',
-            "filters": ['I doubt it likes this very much'],
+            "filters": [{'I doubt it likes this'=>'very much'}],
             "sort": {
               "body": 'desc'
             }

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'search', type: :request do
         let(:search) do
           { "search": {
             "match_text": 'hello',
-            "filters": [{'I doubt it likes this'=>'very much'}],
+            "filters": [{ 'I doubt it likes this' => 'very much' }],
             "sort": {
               "body": 'desc'
             }

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -38,4 +38,13 @@ module Helpers
   def sign_in(user)
     request.headers['token'] = user.token
   end
+
+  def build_results(user, scope, stage_params)
+    search_params = build_search_params(stage_params)
+    SearchSupport::ResultsBuilder.new(
+        user: user,
+        scope: scope,
+        search_params: search_params
+    )
+  end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -42,9 +42,9 @@ module Helpers
   def build_results(user, scope, stage_params)
     search_params = build_search_params(stage_params)
     SearchSupport::ResultsBuilder.new(
-        user: user,
-        scope: scope,
-        search_params: search_params
+      user: user,
+      scope: scope,
+      search_params: search_params
     )
   end
 end


### PR DESCRIPTION
- Use functional classes, not objects
- Tie in cache reader and writer
- Remove recorder, to ensure search is always recorded, even if it errors
- Change search results to ResultsBuilder
- Add a completed flag to ResultsBuilder, so that we can tie in cache reading
and various early bails (empty search bails forthcoming)
- DRY up the search pipeline specs a little by moving a method to helpers
- Add an exception action to be shared by all pipeline members